### PR TITLE
Fix antlr4 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `pytsql` can be installed with:
+Once the `conda-forge` channel has been enabled, `pytsql` can be installed with `conda`:
 
 ```
 conda install pytsql
 ```
 
-It is possible to list all of the versions of `pytsql` available on your platform with:
+or with `mamba`:
+
+```
+mamba install pytsql
+```
+
+It is possible to list all of the versions of `pytsql` available on your platform with `conda`:
 
 ```
 conda search pytsql --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search pytsql --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search pytsql --channel conda-forge
+
+# List packages depending on `pytsql`:
+mamba repoquery whoneeds pytsql --channel conda-forge
+
+# List dependencies of `pytsql`:
+mamba repoquery depends pytsql --channel conda-forge
 ```
 
 
@@ -68,10 +93,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python >=3.7
     - flit-core >=3.2,<4
   run:
-    - antlr4-python3-runtime >=4.9.2
+    - antlr4-python3-runtime =4.9.2
     - pyodbc >=4.0.30
     - python >=3.7
     - sqlalchemy >=1.4


### PR DESCRIPTION
The current requirement of `>=4.9.2` for the ANTLR4 runtime version is too lenient. Installing `pytsql` through conda now uses 4.10 since that has been recently released, yielding runtime errors in deserialization. We should aim to keep the development and runtime version of ANTLR precisely the same.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
